### PR TITLE
Fix missing math mode for exponent in LaTeX file

### DIFF
--- a/text/daophot.tex
+++ b/text/daophot.tex
@@ -179,7 +179,7 @@ the threshold is determined as follows.
 \item The random noise per pixel is computed from the sky level (found by
 SKY) and the readout noise.
 \begin{center}
-random noise = {\tt SQRT(PHPADU$\ast$SKYMODE + RONOIS^2)}
+random noise = {\tt SQRT(PHPADU$\ast$SKYMODE + RONOIS$^2$)}
 \end{center}
 \item After a FWHM (in pixels) 
 has been supplied, FIND will print a value called the


### PR DESCRIPTION
This is needed to run LaTeX on the file.