### PR TITLE
co_refract: Avoid infinite loop

### DIFF
--- a/pro/co_refract.pro
+++ b/pro/co_refract.pro
@@ -176,7 +176,8 @@ endif else begin
                   last = cur
                   dr = co_refract_forward(cur,P=P[i],T=T[i])
                   cur= a[i] + dr
-                endrep until abs(last-cur)*3600. LT epsilon
+                endrep until (abs(last-cur)*3600. LT epsilon) || $
+                             ~finite(last - cur)
                 aout[i] = cur
         endfor
 endelse


### PR DESCRIPTION
Not sure this is the best way to do this, but it avoids potential infinite loops in my experience.
