### PR TITLE
Fix wrong planet input in example 2

### DIFF
--- a/pro/helio.pro
+++ b/pro/helio.pro
@@ -40,7 +40,7 @@ PRO HELIO, JD, LIST, HRAD, HLONG, HLAT, RADIAN = radian
 ;
 ;       (2) Find heliocentric position of Mars on August 23, 2000 
 ;         IDL> JDCNV, 2000,08,23,0,jd
-;         IDL> HELIO,JD,2,HRAD,HLONG,HLAT
+;         IDL> HELIO,JD,4,HRAD,HLONG,HLAT
 ;                  ===> hrad = 1.6407 AU hlong = 124.3197 hlat = 1.7853
 ;         For comparison, the JPL ephemeris gives
 ;                       hrad = 1.6407 AU hlong = 124.2985 hlat = 1.7845


### PR DESCRIPTION
The examples ask for the heliocentric position of Mars but takes 2 (Venus) as input. 
The output given is correct (for Mars).

Additionally, the link in line 87 now redirects to a [generic page](https://ssd.jpl.nasa.gov/?planets#elem), should it be redirected [here](https://ssd.jpl.nasa.gov/?planet_pos)?