### PR TITLE
Set default polycolor in al_legend when psym=10

### DIFF
--- a/pro/al_legend.pro
+++ b/pro/al_legend.pro
@@ -265,6 +265,7 @@
 ;       Added a check for embedded symbols in the items string array. March 2013. David Fanning
 ;       Implement histogram filling.  J. Sapp  Aug 2015.
 ;       Only set polycolor if using polygon filling W. Landsman Sep 2016
+;       Set default polycolor in case psym=10.  J. Sapp  Sep 2017
 ;       
 ;-
 pro al_legend, items, BOTTOM_LEGEND=bottom, BOX = box, CENTER_LEGEND=center, $
@@ -436,19 +437,22 @@ if n_elements(horizontal) eq 0 then $              ; D=VERTICAL
   else: ;polyspace = polyspace
   endcase
 
- case N_elements(polycolor) of
- 0:    polycolor = replicate('opposite',n)
- 1:    polycolor = replicate(polycolor,n)
- else: ;polycolor = polycolori
- endcase
- 
- empty_polycolor = where(polycolor eq '', n_empty)
- if (n_empty ne 0) then $
-  polycolor[empty_polycolor] = 'background'
- polycolor = cgcolor(temporary(polycolor))
 endif
 
- fill = keyword_set(fill)
+; Set default polycolor -- needed if psym=10
+case N_elements(polycolor) of
+0:    polycolor = replicate('opposite',n)
+1:    polycolor = replicate(polycolor,n)
+else: ;polycolor = polycolori
+endcase
+
+empty_polycolor = where(polycolor eq '', n_empty)
+if (n_empty ne 0) then $
+ polycolor[empty_polycolor] = 'background'
+polycolor = cgcolor(temporary(polycolor))
+
+fill = keyword_set(fill)
+
 if (n_elements(usersym) eq 1) then usersym = 2*[[0,0],[0,1],[1,1],[1,0],[0,0]]-1
 
 ;


### PR DESCRIPTION
This fixes a bug when only psym=10 is set without poly_fill being set.