### PR TITLE
Remove national encoding, switch to UTF-8

### DIFF
--- a/pro/fits_test_checksum.pro
+++ b/pro/fits_test_checksum.pro
@@ -59,7 +59,7 @@
 ;     W. Landsman  SSAI               December 2002
 ;     Return quietly if CHECKSUM keywords not found W. Landsman May 2003
 ;     Add /NOSAVE to CHECKSUM32 calls when possible W. Landsman Sep 2004
-;     New option /TRUST_DATASUM. Mats Löfdahl July 2020
+;     New option /TRUST_DATASUM. Mats LÃ¶fdahl July 2020
 ;-
   On_error,2 
   compile_opt idl2 

--- a/pro/query_irsa_cat.pro
+++ b/pro/query_irsa_cat.pro
@@ -113,7 +113,7 @@ FUNCTION query_irsa_cat, targetname_OR_coords, catalog=catalog, radius=radius, r
 ;    Replace webget with IDLnetURL and redo structues - TYB Aug 2017
 ;-
 
-;Copyright © 2013, California Institute of Technology
+;Copyright Â© 2013, California Institute of Technology
 ;All rights reserved. Based on Government Sponsored Research NAS7-03001 and NNN12AA01C.
 ;
 ;

--- a/pro/read_ipac_table.pro
+++ b/pro/read_ipac_table.pro
@@ -55,7 +55,7 @@ FUNCTION read_ipac_table, filename, table_col_info=table_col_info, table_hdr=tab
 ;      Re-do structures to separate out the data - TYB Aug 2017 
 ;-
 
-;Copyright © 2013, California Institute of Technology
+;Copyright Â© 2013, California Institute of Technology
 ;All rights reserved. Based on Government Sponsored Research NAS7-03001 and NNN12AA01C.
 ;
 ;

--- a/pro/read_ipac_var.pro
+++ b/pro/read_ipac_var.pro
@@ -57,7 +57,7 @@ FUNCTION read_ipac_var, textvar, table_col_info=table_col_info, table_hdr=table_
 ;      Re-do structures to separate out the data - TB Aug 2017 
 ;-
 
-;Copyright © 2013, California Institute of Technology
+;Copyright Â© 2013, California Institute of Technology
 ;All rights reserved. Based on Government Sponsored Research NAS7-03001 and NNN12AA01C.
 ;
 ;

--- a/pro/write_ipac_table.pro
+++ b/pro/write_ipac_table.pro
@@ -79,7 +79,7 @@ PRO write_ipac_table, in_struct, outfile, table_col_info=table_col_info, table_h
 ;       columns - TYB Aug 2017
 ;-
 
-;Copyright © 2013, California Institute of Technology
+;Copyright Â© 2013, California Institute of Technology
 ;All rights reserved. Based on Government Sponsored Research NAS7-03001 and NNN12AA01C.
 ;
 ;


### PR DESCRIPTION
Hi,
there are a few national encoded letters in a few files. I've replaced them with their UTF-8 equivalents.
While it looks the same in github UI, the Unicodes are actually are different (if you see it with default locales in terminal)

This emits a few lintian warnings in its corresponding Debian package, please consider merging :-)